### PR TITLE
feature/0T141-87-agregar-paginacion-a-miembro

### DIFF
--- a/controllers/member.js
+++ b/controllers/member.js
@@ -1,0 +1,26 @@
+const { LIMIT_PAGE } = require('../constants/limit-page.constants');
+const { paginated } = require('../helpers/paginated');
+const db = require("../models");
+
+module.exports = {
+    list: async (req, res) => {
+        try {
+            const { page = 1 } = req.query;
+            const members = await db.Member.findAll();
+            const { results, next, prev } = await paginated(members, LIMIT_PAGE, +page, req);
+            if (results.length === 0) {
+                return res.status(204).json({
+                  ok: false,
+                  msg: 'There are no members created',
+                });
+              }
+            return res.status(200).json({ prev, next, results });
+            });
+        } catch (error) {
+            return res.status(500).json({
+                message: 'internal server error',
+                data: error
+            });
+        }
+    },
+}; 


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Miembros paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page