### PR TITLE
Feature/ot141 88 agregar paginación a testimonio

### DIFF
--- a/controllers/testimony.js
+++ b/controllers/testimony.js
@@ -1,3 +1,5 @@
+const { LIMIT_PAGE } = require('../constants/limit-page.constants');
+const { paginated } = require('../helpers/paginated');
 const db = require('../models');
 
 const createTestimony = async (req, res) => {
@@ -65,7 +67,34 @@ const updateTestimony = async (req, res) => {
   }
 };
 
+const getTestimonials = async (req, res) => {
+  try {
+    const { page = 1 } = req.query;
+    const { results, next, prev } = await paginated(db.Testimony, LIMIT_PAGE, +page, req);
+    if (results.length === 0) {
+      return res.status(200).json({
+        message: 'There are no testimonies',
+      });
+    }
+    return res.status(200).json({
+      prev,
+      next,
+      results,
+    });
+  } catch (err) {
+    return res.status(503).json({
+      meta: {
+        status: 503,
+        ok: false,
+      },
+      data: null,
+      errors: { msg: 'Server not available' },
+    });
+  }
+};
+
 module.exports = {
   createTestimony,
   updateTestimony,
+  getTestimonials,
 };

--- a/helpers/paginated.js
+++ b/helpers/paginated.js
@@ -11,10 +11,10 @@ const paginated = async (model, limit, page, req) => {
   const existNext = Math.floor(count / limit) > page;
 
   const prev = existPrev
-    ? `${req.protocol}://${req.get('host')}/categories?page=${page}`
+    ? `${req.protocol}://${req.get('host')}${req.baseUrl}?page=${page}`
     : null;
   const next = existNext
-    ? `${req.protocol}://${req.get('host')}/categories?page=${page + 2}`
+    ? `${req.protocol}://${req.get('host')}${req.baseUrl}?page=${page + 2}`
     : null;
 
   return { results, next, prev };

--- a/routes/testimony.js
+++ b/routes/testimony.js
@@ -1,5 +1,5 @@
 const router = require('express').Router();
-const { createTestimony, updateTestimony } = require('../controllers/testimony');
+const { createTestimony, updateTestimony, getTestimonials } = require('../controllers/testimony');
 
 const {
   verifyToken,
@@ -7,6 +7,12 @@ const {
   validationsTestimony,
   validateErrors,
 } = require('../middlewares');
+
+router.get(
+  '/',
+  verifyToken,
+  getTestimonials,
+);
 
 // Create testimony
 router.post(


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Testimonios paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page