### PR TITLE
add testimonials tests

### DIFF
--- a/tests/endpoints/testimonials.test.js
+++ b/tests/endpoints/testimonials.test.js
@@ -62,7 +62,7 @@ describe('POST /testimonials', () => {
       .expect("Content-Type", /application\/json/);
   });
 
-  it('It should return 400 when validations fail', async () => {
+  it('It should return 422 when validations fail', async () => {
     const user = {
       email: 'admin1@test.com',
       password: 'admin1',
@@ -75,7 +75,7 @@ describe('POST /testimonials', () => {
       .post("/testimonials")
       .send(testimony)
       .auth(token, { type: "bearer" })
-      .expect(400)
+      .expect(422)
       .expect("Content-Type", /application\/json/);
   });
 

--- a/tests/endpoints/testimonials.test.js
+++ b/tests/endpoints/testimonials.test.js
@@ -1,0 +1,167 @@
+/* eslint-disable */
+const supertest = require('supertest');
+const app = require('../../app');
+const db = require('../../models');
+const activitieHelper = require('../activities.test.helpers');
+const { ROLE_ADMIN, ROLE_USER } = require('../../constants/user.constants');
+
+const server = app.listen(process.env.PORT_TEST);
+const api = supertest(app);
+
+const configUsers = [
+  {
+    roleId: ROLE_ADMIN,
+    quantity: 1,
+    firstName: 'User',
+    lastName: 'Admin',
+    email: 'admin',
+  },
+  {
+    roleId: ROLE_USER,
+    quantity: 1,
+    firstName: 'User',
+    lastName: 'Regular',
+    email: 'user',
+  },
+];
+
+beforeEach(async () => {
+  await db.User.destroy({
+    truncate: true,
+  });
+  await db.Activity.destroy({
+    truncate: true,
+  });
+  await activitieHelper.createUsers(configUsers);
+  await activitieHelper.createActivities();
+});
+
+describe('POST /testimonials', () => {
+  it('It should return 403, token is required', async () => {
+    const { text: message } = await api.post('/testimonials')
+      .expect(403)
+      .expect("Content-Type", /application\/json/);
+    expect(message).toContain('A token is required for authentication');
+  });
+
+  it('It should return 401 when creating testimony as regular user', async () => {
+    const user = {
+      email: 'user1@test.com',
+      password: 'user1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const testimony = {
+      name: 'Testimony name',
+      content: 'Testimony Content'
+    }
+    await api
+      .post("/testimonials")
+      .send(testimony)
+      .auth(token, { type: "bearer" })
+      .expect(401)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  it('It should return 400 when validations fail', async () => {
+    const user = {
+      email: 'admin1@test.com',
+      password: 'admin1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const testimony = {
+      name: 'Testimony name',
+    }
+    await api
+      .post("/testimonials")
+      .send(testimony)
+      .auth(token, { type: "bearer" })
+      .expect(400)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  it('It should return 201 when testimony successfully created', async () => {
+    const user = {
+      email: 'admin1@test.com',
+      password: 'admin1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const newTestimony = {
+      name: 'Testimony name',
+      content: 'Testimony Content'
+    };
+    const { body } = await await api
+      .post("/testimonials")
+      .send(newTestimony)
+      .auth(token, { type: "bearer" })
+      .expect(201)
+      .expect("Content-Type", /application\/json/);
+    expect(body.data.name).toBe(newTestimony.name)
+    expect(body.data.content).toBe(newTestimony.content)
+  });
+});
+
+describe('PUT /testimonials/:id', () => {
+  it('It should return 403, token is required', async () => {
+    const { text: message } = await api.post('/testimonials').expect(403);
+    expect(message).toContain('A token is required for authentication');
+  });
+
+  it('It should return 404 testimony not found', async () => {
+    const user = {
+      email: 'admin1@test.com',
+      password: 'admin1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const newTestimonyData = {
+      name: 'New Testimony name',
+      content: 'New Testimony Content'
+    }
+    await api
+      .put("/testimonials/99999")
+      .send(newTestimonyData)
+      .auth(token, { type: "bearer" })
+      .expect(404)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  it('It should return 401 when updating an testimony as regular user', async () => {
+    const user = {
+      email: 'user1@test.com',
+      password: 'user1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const newTestimonyData = {
+      name: 'Updated Testimony Name',
+      content: 'Updated Testimony Content'
+    }
+    await api
+      .put("/testimonials/1")
+      .send(newTestimonyData)
+      .auth(token, { type: "bearer" })
+      .expect(401)
+      .expect("Content-Type", /application\/json/);
+  });
+
+  it('It should return 200 when updating an testimony successfully', async () => {
+    const user = {
+      email: 'admin1@test.com',
+      password: 'admin1',
+    };
+    const { body: {token} } = await api.post('/auth/login').send(user);
+    const newTestimonyData = {
+      name: 'Updated Testimony Name',
+      content: 'Updated Testimony Content'
+    }
+    const { body } = await api
+      .put("/testimonials/1")
+      .send(newTestimonyData)
+      .auth(token, { type: "bearer" })
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+    expect(body.data.name).toBe(newTestimonyData.name)
+  });
+});
+
+afterAll(() => {
+  server.close();
+});

--- a/tests/endpoints/testimonials.test.js
+++ b/tests/endpoints/testimonials.test.js
@@ -2,7 +2,7 @@
 const supertest = require('supertest');
 const app = require('../../app');
 const db = require('../../models');
-const activitieHelper = require('../activities.test.helpers');
+const testimonyHelper = require('../testimonials.test.helpers');
 const { ROLE_ADMIN, ROLE_USER } = require('../../constants/user.constants');
 
 const server = app.listen(process.env.PORT_TEST);
@@ -29,11 +29,11 @@ beforeEach(async () => {
   await db.User.destroy({
     truncate: true,
   });
-  await db.Activity.destroy({
+  await db.Testimony.destroy({
     truncate: true,
   });
-  await activitieHelper.createUsers(configUsers);
-  await activitieHelper.createActivities();
+  await testimonyHelper.createUsers(configUsers);
+  await testimonyHelper.createTestimonials();
 });
 
 describe('POST /testimonials', () => {

--- a/tests/testimonials.test.helpers.js
+++ b/tests/testimonials.test.helpers.js
@@ -1,0 +1,43 @@
+/* eslint-disable */
+const db = require('../models');
+const password = require('../helpers/password');
+
+module.exports = {
+  createUsers: async (configUsers) => {
+    let users = []
+    for await (const item of configUsers) {
+      for (let i=1; i <= item.quantity; i++) {
+        users.push({
+          firstName: `${item.firstName} ${i}`,
+          lastName: item.lastName,
+          email: `${item.email}${i}@test.com`,
+          password: await password.encrypt(`${item.email}${i}`),
+          roleId: item.roleId,
+          photo: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+      }
+    }
+    await db.User.bulkCreate(users);
+  },
+  createTestimonials: async () => {
+    await db.Testimony.bulkCreate([
+      {
+        name: 'Testimony 1',
+        image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+        content: 'Content Testimony 1',
+      },
+      {
+        name: 'Testimony 2',
+        image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+        content: 'Content Testimony 2',
+      },
+      {
+        name: 'Testimony 3',
+        image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+        content: 'Content Testimony 3',
+      },
+    ])
+  }
+};


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de tests de /testimonials
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.